### PR TITLE
Add missing `.length`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ function isNumber(str) {
 // TODO: smaller functions should be extracted from this
 export function isAcceptable (phrase, minCharLength, maxWordsLength) {
   // a phrase must have a min length in characters
-  if(phrase < minCharLength) {
+  if(phrase.length < minCharLength) {
     return false
   }
   // a phrase must have a max number of words


### PR DESCRIPTION
Going through the code to get it to work in TS, I've noticed `phrase < minCharLength` and inferred `phrase` was of type `string` while `minCharLength` is of type `number` and that, plus the comment above, made me think it was meant to be `phrase.length < minCharLength`.